### PR TITLE
Implemented repo name query filter

### DIFF
--- a/lib/document_retrieval/query_processor.rb
+++ b/lib/document_retrieval/query_processor.rb
@@ -74,6 +74,7 @@ class QueryProcessor
   def simplify_query(user_query)
     query = user_query
 
+    # parse the query for file extension filter e: .ext
     ext_list = []
     ext_matches_list = []
     user_query.scan(/e: *[.][a-z]+/) do |match|

--- a/lib/document_retrieval/query_processor.rb
+++ b/lib/document_retrieval/query_processor.rb
@@ -4,7 +4,7 @@ class QueryProcessor
 
   def initialize(user_query)
     @docs = DocumentCollection.new
-    @query, @is_howto = simplify_query(user_query)
+    @query, @is_howto, @ext_list = simplify_query(user_query)
     @ranker = Ranker.new(@query, @docs)
   end
 
@@ -12,6 +12,10 @@ class QueryProcessor
     index_to_url, init_index = get_index_to_url
 
     index_to_url[init_index].each do |url, pos_list|
+
+      # filter by filename extension
+      next if @ext_list.length != 0 && !@ext_list.include?(url[url.rindex('.')..url.length])
+
       h = {}
       t = 0
       cnt = 0
@@ -68,15 +72,27 @@ class QueryProcessor
   end
 
   def simplify_query(user_query)
+    query = user_query
+
+    ext_list = []
+    ext_matches_list = []
+    user_query.scan(/e: *[.][a-z]+/) do |match|
+      ext_matches_list << match
+      ext_list << match[match.index('.')..match.length]
+    end
+    ext_matches_list.each do |match|
+      query = query.gsub(match, ' ')
+    end
+
     is_howto = /how to .*/ =~ user_query.gsub(/[^a-z ]/i, ' ')
-    query = user_query.gsub(/[^a-z ]/i, ' ').split()
+    query = query.gsub(/[^a-z ]/i, ' ').split()
     simple_query = []
     query.each do |word|
       token = Stemmer::stem_word(word.downcase)
       simple_query << token if !simple_query.include? word
     end
     simple_query = simple_query[2...simple_query.length] if is_howto
-    return simple_query, is_howto
+    return simple_query, is_howto, ext_list
   end
 
 end


### PR DESCRIPTION
The user can filter the results by repo name by adding r: repo_name to the query. For example:
android r: kotlin